### PR TITLE
Expose en passant square as function

### DIFF
--- a/src/Game/Chess.hs
+++ b/src/Game/Chess.hs
@@ -31,7 +31,7 @@ module Game.Chess (
 , PieceType(..), Castle(..)
 , Position, startpos, color, moveNumber, halfMoveClock, pieceAt, inCheck
 , castlingRights, canCastleKingside, canCastleQueenside
-, insufficientMaterial, repetitions
+, insufficientMaterial, repetitions, enPassantSquare
   -- ** Converting from/to Forsyth-Edwards-Notation
 , fromFEN, toFEN
   -- * Chess moves

--- a/src/Game/Chess/Internal.hs
+++ b/src/Game/Chess/Internal.hs
@@ -507,6 +507,11 @@ castlingRights Position{flags} = wks . wqs . bks . bqs $ [] where
   bqs xs | flags `testMask` crbQs = (Black, Queenside):xs
          | otherwise              = xs
 
+enPassantSquare :: Position -> Maybe Sq
+enPassantSquare Position{flags} = case flags .&. epMask of
+  0 -> Nothing
+  x -> Just $ toEnum $ bitScanForward x
+
 canCastleKingside, canCastleQueenside :: Position -> Bool
 canCastleKingside pos@Position{qbb} = canCastleKingside' pos (occupied qbb)
 canCastleQueenside pos@Position{qbb} = canCastleQueenside' pos (occupied qbb)


### PR DESCRIPTION
Exposes function which allows the en passant square to be selected from a position, allowing the full FEN record to be accessible without parsing the string.