### PR TITLE
Add HasCallStack to partial doPly and toSAN

### DIFF
--- a/src/Game/Chess/Internal.hs
+++ b/src/Game/Chess/Internal.hs
@@ -34,6 +34,7 @@ import Game.Chess.Internal.Square (IsSquare(toIndex, toRF), Sq(..), toCoord)
 import Game.Chess.Internal.QuadBitboard (QuadBitboard)
 import qualified Game.Chess.Internal.QuadBitboard as QBB
 import Text.Read (readMaybe)
+import GHC.Stack (HasCallStack)
 
 capturing :: Position -> Ply -> Maybe PieceType
 capturing pos@Position{flags} (plyTarget -> to)
@@ -337,7 +338,7 @@ shiftNNW w = w `unsafeShiftL` 15 .&. notHFile
 --
 -- This function checks if the move is actually legal and throws and error
 -- if it isn't.  See 'unsafeDoPly' for a version that omits the legality check.
-doPly :: Position -> Ply -> Position
+doPly :: HasCallStack => Position -> Ply -> Position
 doPly p m
   | m `elem` legalPlies p = unsafeDoPly p m
   | otherwise        = error "Game.Chess.doPly: Illegal move"

--- a/src/Game/Chess/SAN.hs
+++ b/src/Game/Chess/SAN.hs
@@ -48,6 +48,7 @@ import Text.Megaparsec ( optional, (<|>), empty, (<?>), chunk, parse,
                          MonadParsec(try, token),
                          Stream, TraversableStream, VisualStream,
                          Token, Tokens, chunkLength )
+import GHC.Stack (HasCallStack)
 
 type Parser s = Parsec Void s
 
@@ -209,7 +210,7 @@ fromSAN :: (VisualStream s, TraversableStream s, SANToken (Token s), IsString (T
         => Position -> s -> Either String Ply
 fromSAN pos = first errorBundlePretty . parse (relaxedSAN pos) ""
 
-toSAN :: IsString s => Position -> Ply -> s
+toSAN :: (HasCallStack, IsString s) => Position -> Ply -> s
 toSAN pos m
   | m `elem` legalPlies pos = fromString $ unsafeToSAN pos m
   | otherwise               = error "Game.Chess.toSAN: Illegal move"


### PR DESCRIPTION
These help to pin-point which exact `doPly` call violated pre-condition. Aids in debugging while developing.