### PR TITLE
Draw detection via Zobrist hashes in Position

### DIFF
--- a/app/polyplay.hs
+++ b/app/polyplay.hs
@@ -135,13 +135,12 @@ draw pos = insufficientMaterial pos || stalemate pos
 play :: Runtime -> IO ([Ply], Outcome)
 play rt@Runtime{book, history, active, passive, clock} = do
   let pos = uncurry (foldl' unsafeDoPly) history
-  let poss = snd $ uncurry (mapAccumL (\p pl -> (unsafeDoPly p pl, p))) history
   clockRemaining clock (color pos) >>= \case
     Nothing -> pure (snd history, Win . opponent . color $ pos)
     Just _ ->
       if | draw pos    -> pure (snd history, Draw)
          | checkmate pos -> pure (snd history, Win . opponent . color $ pos)
-         | Just (n, _) <- repetitions poss
+         | n <- repetitions pos
          , n >= 3        -> pure (snd history, Draw)
          | otherwise     -> case bookPly book pos of
              Just r -> do

--- a/chessIO.cabal
+++ b/chessIO.cabal
@@ -35,13 +35,13 @@ source-repository head
 
 library
   exposed-modules:
-       Game.Chess
-       Game.Chess.ECO
-       Game.Chess.PGN
-       Game.Chess.Polyglot
-       Game.Chess.SAN
-       Game.Chess.Tree
-       Game.Chess.UCI
+      Game.Chess
+      Game.Chess.ECO
+      Game.Chess.PGN
+      Game.Chess.Polyglot
+      Game.Chess.SAN
+      Game.Chess.Tree
+      Game.Chess.UCI
   other-modules:
       Game.Chess.Internal
       Game.Chess.Internal.ECO

--- a/chessIO.cabal
+++ b/chessIO.cabal
@@ -35,13 +35,13 @@ source-repository head
 
 library
   exposed-modules:
-      Game.Chess
-      Game.Chess.ECO
-      Game.Chess.PGN
-      Game.Chess.Polyglot
-      Game.Chess.SAN
-      Game.Chess.Tree
-      Game.Chess.UCI
+       Game.Chess
+       Game.Chess.ECO
+       Game.Chess.PGN
+       Game.Chess.Polyglot
+       Game.Chess.SAN
+       Game.Chess.Tree
+       Game.Chess.UCI
   other-modules:
       Game.Chess.Internal
       Game.Chess.Internal.ECO

--- a/chessIO.cabal
+++ b/chessIO.cabal
@@ -45,9 +45,9 @@ library
   other-modules:
       Game.Chess.Internal
       Game.Chess.Internal.ECO
+      Game.Chess.Internal.HashConstants
       Game.Chess.Internal.QuadBitboard
       Game.Chess.Internal.Square
-      Game.Chess.Polyglot.Hash
       Paths_chessIO
   hs-source-dirs:
       src
@@ -237,4 +237,49 @@ test-suite polyglot
     , vector
     , vector-binary-instances
     , vector-instances
+  default-language: Haskell2010
+
+test-suite internal 
+  type: exitcode-stdio-1.0
+  main-is: Hashing.hs
+  hs-source-dirs:
+      test/internal
+      src/
+  other-modules:
+      Game.Chess.Internal
+      Game.Chess.Internal.HashConstants
+      Game.Chess.Internal.QuadBitboard
+      Game.Chess.Internal.Square
+  build-depends:
+      attoparsec
+    , base >=4.10 && <5
+    , binary
+    , bytestring
+    , chessIO
+    , containers
+    , deepseq
+    , directory
+    , extra
+    , file-embed
+    , hashable
+    , lens
+    , megaparsec >=9.0
+    , mono-traversable
+    , o-clock
+    , parallel
+    , prettyprinter >=1.7.0
+    , process
+    , QuickCheck
+    , random
+    , stm
+    , template-haskell >=2.9.0.0
+    , text
+    , th-compat >=0.1.2
+    , th-lift-instances
+    , time
+    , unordered-containers
+    , vector
+    , vector-binary-instances
+    , vector-instances
+  
   default-language: Haskell2010

--- a/src/Game/Chess/Internal.hs
+++ b/src/Game/Chess/Internal.hs
@@ -123,7 +123,7 @@ instance Show PieceType where
     Queen  -> "Queen"
     King   -> "King"
 
-data Color = Black | White deriving (Eq, Generic, Bounded, Ix, Ord, Lift, Show)
+data Color = Black | White deriving (Eq, Generic, Ix, Ord, Lift, Show)
 
 instance Binary Color
 instance NFData Color

--- a/src/Game/Chess/Internal/QuadBitboard.hs
+++ b/src/Game/Chess/Internal/QuadBitboard.hs
@@ -11,7 +11,7 @@
 module Game.Chess.Internal.QuadBitboard (
   -- * The QuadBitboard data type
   QuadBitboard
-, occupied, black, white
+, occupied, black, white, anyBits
 , pawns, knights, bishops, rooks, queens, kings
 , wPawns, wKnights, wBishops, wRooks, wQueens, wKings
 , bPawns, bKnights, bBishops, bRooks, bQueens, bKings
@@ -82,6 +82,7 @@ bishops  = liftA2 (.&.) pbq nbk
 rooks    = liftA2 (.&.) pnr rqk
 queens   = liftA2 (.&.) pbq rqk
 kings    = liftA2 (.&.) nbk rqk
+anyBits  = liftA2 (.|.) occupied black
 
 wPawns, wKnights, wBishops, wRooks, wQueens, wKings :: QuadBitboard -> Word64
 wPawns   = liftA2 (.&.) pawns (complement . black)

--- a/src/Game/Chess/Polyglot.hs
+++ b/src/Game/Chess/Polyglot.hs
@@ -52,11 +52,11 @@ import           Game.Chess.Internal        (Color (..), Ply (..),
                                              bKscm, bQscm, canCastleKingside,
                                              canCastleQueenside, doPly, move,
                                              startpos, toFEN, unpack,
-                                             unsafeDoPly, wKscm, wQscm)
+                                             unsafeDoPly, wKscm, wQscm,
+                                             hashPosition)
 import           Game.Chess.Internal.Square
 import           Game.Chess.PGN             (Outcome (Undecided), PGN (..),
                                              gameFromForest, weightedForest)
-import           Game.Chess.Polyglot.Hash   (hashPosition)
 import           System.Random              (RandomGen)
 
 data BookEntry a = BE {

--- a/test/internal/Hashing.hs
+++ b/test/internal/Hashing.hs
@@ -1,0 +1,47 @@
+module Main where
+
+import           Numeric                     (showHex)
+import           Data.Maybe                  (fromJust)
+import           Game.Chess.Internal         (Position (Position, key), Ply, doPly, startpos, legalPlies, fromFEN, toFEN, unsafeDoPly)
+import           System.Exit                 (exitSuccess, exitFailure)
+import           Test.QuickCheck             (Arbitrary, arbitrary, Gen, chooseInt, sized, quickCheckResult, withMaxSuccess,
+                                              Result (Success))
+
+newtype MoveSequence = MoveSequence {unwrapMoveSequence :: [Ply]} deriving (Show, Eq, Ord)
+
+instance Arbitrary MoveSequence where
+     arbitrary = fmap MoveSequence . sized $ loop startpos
+      where
+        loop :: Position -> Int -> Gen [Ply]
+        loop _ 0 = return []
+        loop pos n = do
+            let moves = legalPlies pos
+            case length moves of
+                0 -> return []
+                l -> do
+                    ix <- chooseInt (0, length moves - 1)
+                    let move = moves !! ix
+                    subresult <- loop (doPly pos move) $ n - 1
+                    return $ move:subresult
+
+toPositionSequence :: [Ply] -> [Position]
+toPositionSequence plies =
+  let inner _   []     = []
+      inner pos (p:ps) = pos:inner (unsafeDoPly pos p) ps
+    in inner startpos plies
+
+-- Generate a random sequence of moves from the start position. For each ply, convert the board to FEN and back
+-- and check that the newly-computed hashes match the incrementally-updated ones.
+testGameTreeHashes :: MoveSequence -> Bool
+testGameTreeHashes = all hashesMatch . toPositionSequence . unwrapMoveSequence
+  where
+    hashesMatch pos = let
+        k  = key pos
+        k' = key . fromJust . fromFEN . toFEN $ pos
+      in k == k'
+
+main = do
+    result <- quickCheckResult testGameTreeHashes
+    case result of
+        Success{} -> exitSuccess 
+        _ -> exitFailure 


### PR DESCRIPTION
Currently chessIO has no efficient way to detect {three,five}fold repetition draws from a given position, i.e. to tell how many times the position has occurred. The way some modern chess implementations handle this is maintaining a position hash as part of the position data type, and also storing a linked list of hashes of the previous board states (see e.g. [Stockfish](https://github.com/official-stockfish/Stockfish/blob/19a90b45bceb69aa62b5c85366343a7d1cfc695f/src/position.cpp#L876)). Since recomputing the hash of the entire board each move would be expensive, [Zobrist hashing](https://en.wikipedia.org/wiki/Zobrist_hashing) is used to quickly update the hashes with only the changed elements of the board.

(Optimization: in order to detect if a given position is a draw by repetition, we only need to know about the prior board states since the last pawn move or capture.)

chessIO already has some Zobrist hashing code in the Polyglot module, but no support for incrementally updating the hashes. So I've moved that hashing logic under Game.Chess.Internal.

After applying a move to a position in `unsafeDoPly`, I've added a step to XOR the before and after bitboards together -- any 1s indicate changes to the board state. For each detected change to the board state, `unsafeDoPly` looks up the corresponding hash in the Zobrist tables and XORs it with the position hash.

As of 2022-4-12 I'm still ironing out some bugs in the hashing implementation. And then the next step is to implement the hash history updating/searching. But thought I'd send this out for an early review in the meantime. Also: exposing position hashes to library clients would allow them to use transposition tables.